### PR TITLE
Implemented ability to compile files with blanks in their paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Compiles .tex to .pdf using commands like "pdflatex", at current file
 ![Image of Command](https://raw.githubusercontent.com/mathiasfrohlich/vscode-LaTeXCompile/master/images/command.png)
 
 ## Requirements
-Path to file must **not** include "space". relative path => relative_path<br />
 Installed Latex distribution (Supporting cmd: pdflatex) 
 
 Programs Like

--- a/extension.js
+++ b/extension.js
@@ -35,7 +35,7 @@ function activate(context) {
                 throw new Error("Can't create PDF, open a .tex file.");
             }
 
-            var command = 'cd ' + path + ' && ' + vscode.workspace.getConfiguration('latexCompile').compiler + ' ' + fileNameAndType;
+            var command = 'cd ' + quote(path) + ' && ' + vscode.workspace.getConfiguration('latexCompile').compiler + ' ' + quote(fileNameAndType);
 
             //Log the command to run
             console.log(command);
@@ -47,7 +47,7 @@ function activate(context) {
                 cmd = exec(command);
 
             //Make log file to contain console		
-            exec('cd ' + path + ' && type NUL > ' + fileName + ".vscodeLog");
+            exec('cd ' + quote(path) + ' && type NUL > ' + quote(fileName) + ".vscodeLog");
 
             //Subscribe to output
             cmd.stdout.on('data', function(data) {
@@ -81,9 +81,9 @@ function activate(context) {
                 if (vscode.workspace.getConfiguration('latexCompile').openAfterCompile) {
                     setStatusBarText('Launching', "PDF");
                     if (process.platform == 'darwin') {
-                        exec('open ' + pdfFileName);
+                        exec('open ' + quote(pdfFileName));
                     } else {
-                        exec(pdfFileName);
+                        exec(quote(pdfFileName));
                     }
                 } else {
                     vscode.window.showInformationMessage('PDF Compilled at ' + path);
@@ -95,6 +95,12 @@ function activate(context) {
             vscode.window.showErrorMessage(error.message);
         }
     });
+    
+    //Function to put quotation marks around path
+    function quote(path) {
+        return '"' + path + '"';
+    }
+    
     //Function to get file name and type
     function getFileNameAndType(file) {
         var forwardSlash = file.lastIndexOf("/");


### PR DESCRIPTION
Added quotation marks to paths in commands to allow compilation of files that have blanks in their paths. Tested on Mac OS X. Please review
