### PR TITLE
Fixed PDF not opening after compilation in Linux, despite the option …

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -90,6 +90,8 @@ function activate(context) {
                     setStatusBarText('Launching', "PDF");
                     if (process.platform == 'darwin') {
                         exec('open ' + quote(pdfFileName));
+                    } else if (process.platform == 'linux') {
+                        exec('xdg-open ' + quote(pdfFileName));
                     } else {
                         exec(quote(pdfFileName));
                     }


### PR DESCRIPTION
…being turned on. My suggestion is to use [xdg-open](https://portland.freedesktop.org/doc/xdg-open.html) from [xdg-utils](https://www.freedesktop.org/wiki/Software/xdg-utils/) similarly to how open is used on OSX when the platform is Linux. 
